### PR TITLE
Fix shadowing of `output` variable in callback

### DIFF
--- a/pkg/volumize/volumize.go
+++ b/pkg/volumize/volumize.go
@@ -74,7 +74,8 @@ func (v *Volumizer) WaitForVolume(asgName, volumeTag *string) (*ec2.Volume, erro
 	}
 	input := &ec2.DescribeVolumesInput{Filters: filters}
 	err := helpers.WaitFor(10*time.Minute, func() error {
-		output, err := v.ec2.DescribeVolumes(input)
+		var err error
+		output, err = v.ec2.DescribeVolumes(input)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
The `output` variable should have been filled in after callback
was finished, but it was shadowed by using type inference to
define a new variable of the same name.