### PR TITLE
Remove explicit dependencies on `keights-collector.service`

### DIFF
--- a/fpm/usr/lib/systemd/system/keights-share.service
+++ b/fpm/usr/lib/systemd/system/keights-share.service
@@ -1,7 +1,5 @@
 [Unit]
 Description=keights-share service
-Requires=keights-collector.service
-After=keights-collector.service
 
 [Service]
 Type=oneshot

--- a/fpm/usr/lib/systemd/system/keights-templatize-etcd.service
+++ b/fpm/usr/lib/systemd/system/keights-templatize-etcd.service
@@ -1,7 +1,5 @@
 [Unit]
 Description=keights-templatize-etcd service
-Requires=keights-collector.service
-After=keights-collector.service
 
 [Service]
 Type=simple

--- a/fpm/usr/lib/systemd/system/keights-templatize-kube-controller-manager.service
+++ b/fpm/usr/lib/systemd/system/keights-templatize-kube-controller-manager.service
@@ -1,7 +1,5 @@
 [Unit]
 Description=keights-templatize-kube-controller-manager service
-Requires=keights-collector.service
-After=keights-collector.service
 
 [Service]
 Type=simple

--- a/fpm/usr/lib/systemd/system/keights-templatize-kube-proxy.service
+++ b/fpm/usr/lib/systemd/system/keights-templatize-kube-proxy.service
@@ -1,7 +1,5 @@
 [Unit]
 Description=keights-templatize-kube-proxy service
-Requires=keights-collector.service
-After=keights-collector.service
 
 [Service]
 Type=simple

--- a/fpm/usr/lib/systemd/system/keights-templatize-kube-scheduler.service
+++ b/fpm/usr/lib/systemd/system/keights-templatize-kube-scheduler.service
@@ -1,7 +1,5 @@
 [Unit]
 Description=keights-templatize-kube-scheduler service
-Requires=keights-collector.service
-After=keights-collector.service
 
 [Service]
 Type=simple


### PR DESCRIPTION
This prevents these services from running
`keights-collector.service` every time they run, since it has
already run and modified the file `/run/keights-collector/asg`,
which causes these services to be activated through their
corresponding systemd path units.