### PR TITLE
Remove `KEIGHTS_ASG_NAME` environment variable from systemd unit

### DIFF
--- a/fpm/usr/lib/systemd/system/keights-collector.service
+++ b/fpm/usr/lib/systemd/system/keights-collector.service
@@ -4,11 +4,9 @@ Description=keights-collector service
 [Service]
 # Environment=AWS_REGION=
 # Environment=KEIGHTS_VOLUME_TAG=
-Environment=KEIGHTS_ASG_NAME=
 Type=oneshot
 ExecStartPre=/usr/bin/systemd-tmpfiles --create --prefix /run/keights-collector
 ExecStart=/usr/bin/keights collect \
-            -a ${KEIGHTS_ASG_NAME} \
             -v ${KEIGHTS_VOLUME_TAG} \
             -o /run/keights-collector/asg
 


### PR DESCRIPTION
Because the environment variables for the keights-collector
service are configured through a launch configuration, putting the
name of the ASG into it creates a circular dependency. The
keights collect subcommand has already been updated to do a lookup
on the autoscaling group to get the name, and it needed to be
removed from the systemd unit.