### PR TITLE
Add e2e tests to Concourse pipeline

### DIFF
--- a/ci/assets/v1.11/cluster/requirements.txt
+++ b/ci/assets/v1.11/cluster/requirements.txt
@@ -1,5 +1,5 @@
 adal==1.1.0
-ansible==2.6.4
+ansible==2.7.0
 asn1crypto==0.24.0
 awscli==1.16.10
 bcrypt==3.1.4
@@ -21,12 +21,12 @@ kubernetes==7.0.0
 MarkupSafe==1.0
 oauthlib==2.1.0
 openshift==0.7.2
-paramiko==2.4.1
+paramiko==2.4.2
 pyasn1==0.4.4
 pyasn1-modules==0.2.2
-pycparser==2.18
+pycparser==2.19
 PyJWT==1.6.4
-PyNaCl==1.2.1
+PyNaCl==1.3.0
 python-dateutil==2.7.3
 python-string-utils==0.6.0
 PyYAML==3.13

--- a/ci/pipelines/keights.yml
+++ b/ci/pipelines/keights.yml
@@ -68,6 +68,10 @@ jobs:
       version: version-snap
     params:
       KEIGHTS_BRANCH: ((git-branch))
+  - task: run-e2e
+    file: keights-pr/ci/tasks/run-e2e.yml
+    input_mapping:
+      artifacts: build-cluster-artifacts
   on_failure:
     put: keights-pr
     params:

--- a/ci/tasks/run-e2e.yml
+++ b/ci/tasks/run-e2e.yml
@@ -1,0 +1,76 @@
+---
+platform: linux
+
+image_resource:
+  type: docker-image
+  source:
+    repository: alpine
+    tag: '3.8'
+
+inputs:
+- name: artifacts
+
+caches:
+- path: ../../../opt/bin
+
+params:
+  AWS_REGION: us-east-1
+  SONOBUOY_URL: https://github.com/heptio/sonobuoy/releases/download/v0.12.1/sonobuoy_0.12.1_linux_amd64.tar.gz
+  KUBECONFIG: artifacts/kubeconfig
+
+run:
+  path: /bin/sh
+  args:
+  - -e
+  - -c
+  - |
+    if [ ! -x /opt/bin/sonobuoy ]; then
+        wget -O /tmp/sonobuoy.tar.gz ${SONOBUOY_URL}
+        mkdir -p /opt/bin
+        gunzip -c /tmp/sonobuoy.tar.gz | tar -xf - -C /opt/bin sonobuoy
+    fi
+
+    export PATH=/opt/bin:${PATH}
+
+    sonobuoy run
+
+    printf 'Waiting for sonobuoy to come up...'
+    now=`date +%s`
+    end=$((${now}+300))
+    while true; do
+        if [ `date +%s` -gt ${end} ]; then
+            echo ' timeout'
+            exit 1
+        fi
+        sonobuoy status >/dev/null 2>&1 && break || true
+        sleep 1
+    done
+    echo ' ok'
+
+    printf 'Waiting for e2e tests to complete...'
+    now=`date +%s`
+    end=$((${now}+7200))
+    while true; do
+        if [ `date +%s` -gt ${end} ]; then
+            echo ' timeout'
+            exit 1
+        fi
+        if sonobuoy status | grep -q 'still running'; then
+            printf '.'
+            sleep 30
+            continue
+        fi
+        sonobuoy status | grep -q 'Sonobuoy has completed. Use' && break
+        sleep 1
+    done
+    echo ' ok'
+
+    printf 'Checking e2e results...'
+    mkdir results
+    sonobuoy retrieve results
+    if sonobuoy e2e results/*.tar.gz | grep -q 'failed tests'; then
+        echo
+        sonobuoy e2e results/*.tar.gz
+        exit 1
+    fi
+    echo ' ok'

--- a/keights/resources/usr/lib/systemd/system/keights-templatize-kubeadm-config.service
+++ b/keights/resources/usr/lib/systemd/system/keights-templatize-kubeadm-config.service
@@ -6,7 +6,7 @@ After=keights-whisper-controller.service
 [Service]
 Type=simple
 # Environment=AWS_REGION=
-# Environment=KEIGHTS_DOMAIN=
+# Environment=KEIGHTS_CLUSTER_DOMAIN=
 # Environment=KEIGHTS_ETCD_DOMAIN=
 # Environment=KEIGHTS_PREFIX=
 # Environment=KEIGHTS_APISERVER=
@@ -39,7 +39,7 @@ ExecStart=/bin/sh -c ' \
     /usr/bin/keights template \
       -t /usr/share/keights/kubeadm-config.yaml.template \
       -D /var/lib/kubeadm/config.yaml \
-      -v Domain=${KEIGHTS_DOMAIN} \
+      -v ClusterDomain=${KEIGHTS_CLUSTER_DOMAIN} \
       -v EtcdDomain=${KEIGHTS_ETCD_DOMAIN} \
       -v Prefix=${KEIGHTS_PREFIX} \
       -v APIServer=${KEIGHTS_APISERVER} \

--- a/keights/resources/usr/share/keights/kubeadm-config.yaml.template
+++ b/keights/resources/usr/share/keights/kubeadm-config.yaml.template
@@ -30,7 +30,7 @@ etcd:
     - {{ .MyIP }}
     - {{ .Prefix }}-{{ .MyAZ }}.{{ .EtcdDomain }}
 networking:
-  dnsDomain: {{ .Domain }}
+  dnsDomain: {{ .ClusterDomain }}
   podSubnet: {{ .PodSubnet }}
   serviceSubnet: {{ .ServiceSubnet }}
 bootstrapTokens:
@@ -109,7 +109,7 @@ kubeletConfiguration:
     cloudProvider: aws
     clusterDNS:
     - {{ .ClusterDNS }}
-    clusterDomain: k8s.local
+    clusterDomain: {{ .ClusterDomain }}
     containerLogMaxFiles: 5
     containerLogMaxSize: 10Mi
     contentType: application/vnd.kubernetes.protobuf

--- a/stack/ansible/keights-stack/README.md
+++ b/stack/ansible/keights-stack/README.md
@@ -26,6 +26,10 @@ All role variables go under a top level dictionary `keights_stack`.
 
 `resource_bucket`: (Required, type *string*) - S3 bucket used for storing and retrieving artifacts.
 
+`cluster_domain`: (Optional, type *string*, default `cluster.local`) - Domain used by internal Kubernetes network.
+
+`etcd_domain`: (Optional, type *string*, default `{{cluster_name}}.local`) - Domain used by etcd servers, by default this is derived from the cluster name.
+
 `cfn_role_arn`: (Optional, type *string*) - IAM service role ARN to be passed to CloudFormation. See [AWS documentation on using CloudFormation with a service role](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-iam-servicerole.html) for more details.
 
 `k8s_version`: (Optional, type *string*) - Version of Kubernetes. This defaults to the version corresponding with the `keights-stack` version, for example if the `keights-stack` version is `1.10.7-3`, then `k8s_version` is `1.10.7`. Versions other than the default will not be tested.

--- a/stack/ansible/keights-stack/tasks/main.yml
+++ b/stack/ansible/keights-stack/tasks/main.yml
@@ -8,6 +8,7 @@
 - name: set default values
   set_fact:
     cluster_dns: '{{ keights_stack.masters.service_cidr.split(".")[:-1] | join(".") }}.10'
+    default_etcd_domain: '{{ "{}.local".format(keights_stack.cluster_name) }}'
     k8s_version: '{{ keights_stack.k8s_version | default(keights_version.split("-")[0]) }}'
     default_image: 'debian-stretch-k8s-hvm-amd64-{{ keights_version }}'
     cache_dir: '{{ playbook_dir }}/.cache'
@@ -85,6 +86,7 @@
     template_parameters:
       VpcId: '{{ keights_stack.vpc_id }}'
       ClusterName: '{{ keights_stack.cluster_name }}'
+      EtcdDomain: '{{ keights_stack.etcd_domain | default(default_etcd_domain) }}'
       KmsKeyId: '{{ keights_stack.kms_key_id }}'
       ApiAccessCidr: '{{ keights_stack.api_access_cidr }}'
       # TODO: give masters and nodes separate ssh_access_cidr
@@ -121,6 +123,8 @@
       PodCidr: '{{ keights_stack.masters.pod_cidr }}'
       ServiceCidr: '{{ keights_stack.masters.service_cidr }}'
       ClusterDns: '{{ cluster_dns }}'
+      ClusterDomain: '{{ keights_stack.cluster_domain | default("cluster.local") }}'
+      EtcdDomain: '{{ keights_stack.etcd_domain | default(default_etcd_domain) }}'
       EtcdVolumeSize: '{{ keights_stack.masters.etcd_volume_size | default(10) }}'
       EtcdDevice: '{{ keights_stack.masters.etcd_device | default("xvdg") }}'
       EtcdInternalDevice: '{{ keights_stack.masters.etcd_internal_device | default("/dev/xvdg") }}'

--- a/stack/ansible/keights-system/tasks/main.yml
+++ b/stack/ansible/keights-system/tasks/main.yml
@@ -83,3 +83,15 @@
   until: apply_k8s_manifests is succeeded
   retries: 12
   delay: 10
+
+- name: wait for network to come up
+  k8s_facts:
+    kubeconfig: '{{ cache_dir.path }}/kubeconfig'
+    kind: Pod
+    namespace: kube-system
+    label_selectors:
+    - k8s-app in (calico-node, calico-typha, kube-router)
+  register: pods
+  until: pods | json_query('resources[].status.containerStatuses[].state | map(&keys(@)[?@ != `running`], @)[]') == []
+  retries: 60
+  delay: 10

--- a/stack/cloudformation/common.yml
+++ b/stack/cloudformation/common.yml
@@ -9,6 +9,9 @@ Parameters:
   ClusterName:
     Description: Name of Kubernetes cluster
     Type: String
+  EtcdDomain:
+    Description: Domain name given to etcd Route53 zone.
+    Type: String
   KmsKeyId:
     Description: KMS key used to manage secrets
     Type: String
@@ -175,7 +178,7 @@ Resources:
   HostedZone:
     Type: AWS::Route53::HostedZone
     Properties:
-      Name: !Sub ${ClusterName}.local
+      Name: !Sub ${EtcdDomain}
       VPCs:
         - VPCId: !Ref VpcId
           VPCRegion: !Ref AWS::Region

--- a/stack/cloudformation/master.yml
+++ b/stack/cloudformation/master.yml
@@ -75,6 +75,13 @@ Parameters:
       the value of ServiceCidr + 10
     Default: 10.1.0.10
     Type: String
+  ClusterDomain:
+    Description: Domain name used for cluster network.
+    Default: cluster.local
+    Type: String
+  EtcdDomain:
+    Description: Domain name given to etcd Route53 zone.
+    Type: String
   EtcdVolumeSize:
     Description: Size of etcd volume in GB
     Default: 10
@@ -149,7 +156,7 @@ Resources:
           ASG_NAME: !Ref AWS::StackName
           DNS_TTL: 15
           HOST_BASE_NAME: etcd
-          HOSTED_ZONE_NAME: !Sub ${ClusterName}.local
+          HOSTED_ZONE_NAME: !Sub ${EtcdDomain}
           HOSTED_ZONE_ID: !Ref HostedZoneId
 
   AutoNamingEventsRule:
@@ -326,8 +333,8 @@ Resources:
                 content: |
                   [Service]
                   Environment=AWS_REGION=${AWS::Region}
-                  Environment=KEIGHTS_DOMAIN=k8s.local
-                  Environment=KEIGHTS_ETCD_DOMAIN=${ClusterName}.local
+                  Environment=KEIGHTS_CLUSTER_DOMAIN=${ClusterDomain}
+                  Environment=KEIGHTS_ETCD_DOMAIN=${EtcdDomain}
                   Environment=KEIGHTS_PREFIX=etcd
                   Environment=KEIGHTS_APISERVER=${LoadBalancer.DNSName}
                   Environment=KEIGHTS_API_PORT=443


### PR DESCRIPTION
This includes a change to the `keights-system` Ansible role to
wait for the network, otherwise `sonobuoy`, used for running the
e2e tests, can fail to start properly. And because `sonobuoy`
keeps running on exit, the pod does not restart and recover.

This also changes the default cluster domain from `k8s.local` to
`cluster.local`, as setting to anything other than `cluster.local`
causes DNS e2e tests to fail. This may be overridden with Ansible
and CloudFormation parameters.