### PR TITLE
Fix version so it always starts with `v` character

### DIFF
--- a/ci/tasks/build-ami.yml
+++ b/ci/tasks/build-ami.yml
@@ -38,6 +38,8 @@ run:
     . /python/bin/activate
 
     version=`cat ${VERSION_FILE}`
+    first_char=`echo ${version} | cut -c 1`
+    [ "${first_char=}" != v ] && version="v${version}"
 
     cd repo/stack/ami/debian
-    /opt/bin/packer build -var keights-version=v${version} build.json
+    /opt/bin/packer build -var keights-version=${version} build.json


### PR DESCRIPTION
The build-ami Concourse task may be called with a version that
begins with a `v` or not, so this ensures that the version passed
to Packer always starts with `v`.