### PR TITLE
Add the ability to override Route53 zone with an unmanaged zone

### DIFF
--- a/ci/tasks/make-keights.yml
+++ b/ci/tasks/make-keights.yml
@@ -5,7 +5,7 @@ image_resource:
   type: docker-image
   source:
     repository: golang
-    tag: '1.11'
+    tag: '1.11.1'
 
 inputs:
 - name: repo

--- a/stack/ansible/keights-stack/README.md
+++ b/stack/ansible/keights-stack/README.md
@@ -30,6 +30,10 @@ All role variables go under a top level dictionary `keights_stack`.
 
 `etcd_domain`: (Optional, type *string*, default `{{cluster_name}}.local`) - Domain used by etcd servers, by default this is derived from the cluster name.
 
+`etcd_hosted_zone_id`: (Optional, type *string*, default `''`) - Route53 hosted zone ID used for etcd DNS records. If not provided, a private hosted zone will be created. The name of the zone with this ID must match the value of `etcd_domain`.
+
+`etcd_prefix`: (Optional, type *string*, default `etcd`) - Prefix given to etcd DNS records. This will be combined with the availability zone and the value of the `etcd_domain` parameter.
+
 `cfn_role_arn`: (Optional, type *string*) - IAM service role ARN to be passed to CloudFormation. See [AWS documentation on using CloudFormation with a service role](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-iam-servicerole.html) for more details.
 
 `k8s_version`: (Optional, type *string*) - Version of Kubernetes. This defaults to the version corresponding with the `keights-stack` version, for example if the `keights-stack` version is `1.10.7-3`, then `k8s_version` is `1.10.7`. Versions other than the default will not be tested.

--- a/stack/ansible/keights-stack/tasks/main.yml
+++ b/stack/ansible/keights-stack/tasks/main.yml
@@ -87,6 +87,7 @@
       VpcId: '{{ keights_stack.vpc_id }}'
       ClusterName: '{{ keights_stack.cluster_name }}'
       EtcdDomain: '{{ keights_stack.etcd_domain | default(default_etcd_domain) }}'
+      EtcdHostedZoneId: '{{ keights_stack.etcd_hosted_zone_id | default("") }}'
       KmsKeyId: '{{ keights_stack.kms_key_id }}'
       ApiAccessCidr: '{{ keights_stack.api_access_cidr }}'
       # TODO: give masters and nodes separate ssh_access_cidr
@@ -125,6 +126,7 @@
       ClusterDns: '{{ cluster_dns }}'
       ClusterDomain: '{{ keights_stack.cluster_domain | default("cluster.local") }}'
       EtcdDomain: '{{ keights_stack.etcd_domain | default(default_etcd_domain) }}'
+      EtcdPrefix: '{{ keights_stack.etcd_prefix | default("etcd") }}'
       EtcdVolumeSize: '{{ keights_stack.masters.etcd_volume_size | default(10) }}'
       EtcdDevice: '{{ keights_stack.masters.etcd_device | default("xvdg") }}'
       EtcdInternalDevice: '{{ keights_stack.masters.etcd_internal_device | default("/dev/xvdg") }}'
@@ -133,7 +135,7 @@
       KubernetesVersion: '{{ k8s_version }}'
       KeightsVersion: '{{ keights_version }}'
       ResourceBucket: '{{ keights_stack.resource_bucket }}'
-      HostedZoneId: '{{ common_stack.stack_outputs.HostedZoneId }}'
+      HostedZoneId: '{{ common_stack.stack_outputs.HostedZoneId | default(keights_stack.etcd_hosted_zone_id) }}'
     tags:
       KubernetesCluster: '{{ keights_stack.cluster_name }}'
       k8s:version: '{{ k8s_version }}'

--- a/stack/cloudformation/common.yml
+++ b/stack/cloudformation/common.yml
@@ -10,8 +10,17 @@ Parameters:
     Description: Name of Kubernetes cluster
     Type: String
   EtcdDomain:
-    Description: Domain name given to etcd Route53 zone.
+    Description: >-
+      Domain name given to Route53 hosted zone for etcd records.
+      If empty, the EtcdHostedZoneId parameter must be provided.
     Type: String
+    Default: ''
+  EtcdHostedZoneId:
+    Description: >-
+      ID of Route53 hosted zone for etcd records. If empty,
+      a private zone will be created.
+    Type: String
+    Default: ''
   KmsKeyId:
     Description: KMS key used to manage secrets
     Type: String
@@ -23,6 +32,10 @@ Parameters:
     Description: CIDR block given ssh access to cluster
     Default: 0.0.0.0/0
     Type: String
+
+Conditions:
+  HasManagedHostedZone: !Equals [!Ref EtcdHostedZoneId, '']
+  HasUnmanagedHostedZone: !Not [!Equals [!Ref EtcdHostedZoneId, '']]
 
 Resources:
   LoadBalancerSecurityGroup:
@@ -177,6 +190,7 @@ Resources:
 
   HostedZone:
     Type: AWS::Route53::HostedZone
+    Condition: HasManagedHostedZone
     Properties:
       Name: !Sub ${EtcdDomain}
       VPCs:
@@ -186,6 +200,7 @@ Resources:
   K8sMasterAccess:
     Type: AWS::IAM::ManagedPolicy
     Properties:
+      Roles: [!Ref MasterRole]
       PolicyDocument:
         Version: '2012-10-17'
         Statement:
@@ -261,6 +276,7 @@ Resources:
   K8sNodeAccess:
     Type: AWS::IAM::ManagedPolicy
     Properties:
+      Roles: [!Ref NodeRole]
       PolicyDocument:
         Version: '2012-10-17'
         Statement:
@@ -287,6 +303,7 @@ Resources:
   K8sLambdaAccess:
     Type: AWS::IAM::ManagedPolicy
     Properties:
+      Roles: [!Ref LambdaRole]
       PolicyDocument:
         Version: '2012-10-17'
         Statement:
@@ -313,11 +330,34 @@ Resources:
               - kms:Encrypt
             Resource:
               - !Sub 'arn:aws:kms:${AWS::Region}:${AWS::AccountId}:key/${KmsKeyId}'
+
+  K8sLambdaRoute53ManagedAccess:
+    Type: AWS::IAM::ManagedPolicy
+    Condition: HasManagedHostedZone
+    Properties:
+      Roles: [!Ref LambdaRole]
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
           - Effect: Allow
             Action:
               - route53:ChangeResourceRecordSets
             Resource:
               - !Sub 'arn:aws:route53:::hostedzone/${HostedZone}'
+
+  K8sLambdaRoute53UnmanagedAccess:
+    Type: AWS::IAM::ManagedPolicy
+    Condition: HasUnmanagedHostedZone
+    Properties:
+      Roles: [!Ref LambdaRole]
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Action:
+              - route53:ChangeResourceRecordSets
+            Resource:
+              - !Sub 'arn:aws:route53:::hostedzone/${EtcdHostedZoneId}'
 
   MasterRole:
     Type: AWS::IAM::Role
@@ -329,8 +369,6 @@ Resources:
             Principal:
               Service: ec2.amazonaws.com
             Action: sts:AssumeRole
-      ManagedPolicyArns:
-        - !Ref K8sMasterAccess
 
   MasterInstanceProfile:
     Type: AWS::IAM::InstanceProfile
@@ -347,8 +385,6 @@ Resources:
             Principal:
               Service: ec2.amazonaws.com
             Action: sts:AssumeRole
-      ManagedPolicyArns:
-        - !Ref K8sNodeAccess
 
   NodeInstanceProfile:
     Type: AWS::IAM::InstanceProfile
@@ -365,8 +401,6 @@ Resources:
             Principal:
               Service: lambda.amazonaws.com
             Action: sts:AssumeRole
-      ManagedPolicyArns:
-        - !Ref K8sLambdaAccess
 
 Outputs:
   LoadBalancerSecurityGroup:
@@ -411,3 +445,4 @@ Outputs:
   HostedZoneId:
     Description: ID of Route53 DNS hosted zone
     Value: !Ref HostedZone
+    Condition: HasManagedHostedZone

--- a/stack/cloudformation/master.yml
+++ b/stack/cloudformation/master.yml
@@ -82,6 +82,12 @@ Parameters:
   EtcdDomain:
     Description: Domain name given to etcd Route53 zone.
     Type: String
+  EtcdPrefix:
+    Description: >-
+      Prefix given to etcd hostnames. This will be combined with the
+      availability zone and the value of the EtcdDomain parameter.
+    Type: String
+    Default: etcd
   EtcdVolumeSize:
     Description: Size of etcd volume in GB
     Default: 10
@@ -159,8 +165,8 @@ Resources:
         Variables:
           ASG_NAME: !Ref AWS::StackName
           DNS_TTL: 15
-          HOST_BASE_NAME: etcd
-          HOSTED_ZONE_NAME: !Sub ${EtcdDomain}
+          HOST_BASE_NAME: !Ref EtcdPrefix
+          HOSTED_ZONE_NAME: !Ref EtcdDomain
           HOSTED_ZONE_ID: !Ref HostedZoneId
 
   AutoNamingEventsRule:
@@ -318,7 +324,7 @@ Resources:
                   Environment=KEIGHTS_ETCD_DOMAIN=${EtcdDomain}
                   Environment=KEIGHTS_ETCD_CLUSTER_TOKEN=etcd-${ClusterName}
                   Environment=KEIGHTS_ETCD_IMAGE=${EtcdImage}
-                  Environment=KEIGHTS_PREFIX=etcd
+                  Environment=KEIGHTS_PREFIX=${EtcdPrefix}
                   Environment=KEIGHTS_AZS=${AvailabilityZones},
 
               - path: /etc/systemd/system/keights-volumize.service.d/environment.conf
@@ -355,7 +361,7 @@ Resources:
                   Environment=AWS_REGION=${AWS::Region}
                   Environment=KEIGHTS_CLUSTER_DOMAIN=${ClusterDomain}
                   Environment=KEIGHTS_ETCD_DOMAIN=${EtcdDomain}
-                  Environment=KEIGHTS_PREFIX=etcd
+                  Environment=KEIGHTS_PREFIX=${EtcdPrefix}
                   Environment=KEIGHTS_APISERVER=${LoadBalancer.DNSName}
                   Environment=KEIGHTS_POD_SUBNET=${PodCidr}
                   Environment=KEIGHTS_SERVICE_SUBNET=${ServiceCidr}


### PR DESCRIPTION
For etcd hostnames, it may be desirable to use an existing Route53
zone instead of creating one for each cluster. This adds parameters
for specifying a zone that is unmanaged by this automation.