### PR TITLE
Improve resiliency of master initialization

### DIFF
--- a/stack/cloudformation/master.yml
+++ b/stack/cloudformation/master.yml
@@ -229,7 +229,7 @@ Resources:
     CreationPolicy:
       ResourceSignal:
         Count: !Ref NumInstances
-        Timeout: PT15M
+        Timeout: PT30M
     Properties:
       AutoScalingGroupName: !Ref AWS::StackName
       DesiredCapacity: !Ref NumInstances


### PR DESCRIPTION
This improves the volumize command:
The `WaitForVolume()` function adds `status: available` to its
filters when querying AWS. This should make the `AttachVolume`
operation more likely to succeed. Retry is also added around
`AttachVolume` so that it does not abort on the first error.
Length of time to attach and wait for volume is also increased.

The master.yml CloudFormation template has the timeout for
receiving a signal from masters increased to 30 minutes, for cases
where volumize is taking especially long to run.