### PR TITLE
Add release verification step to Concourse pipeline

### DIFF
--- a/ci/pipelines/keights.yml
+++ b/ci/pipelines/keights.yml
@@ -142,12 +142,17 @@ jobs:
 - name: update-pull-request-status
   public: true
   plan:
-  - get: keights-pr
-    trigger: true
-    version: every
-    passed:
-    - build-cluster
-    - upgrade-cluster
+  - aggregate:
+    - get: keights-pr
+      trigger: true
+      version: every
+      passed:
+      - build-cluster
+      - upgrade-cluster
+    - get: version-snap
+      passed:
+      - build-cluster
+      - upgrade-cluster
   - put: keights-pr
     params:
       path: keights-pr
@@ -161,6 +166,14 @@ jobs:
       passed: [update-pull-request-status]
     - get: keights-release
       trigger: true
+    - get: version-snap
+      passed: [update-pull-request-status]
+  - task: verify-release
+    file: keights-release/ci/tasks/verify-release.yml
+    input_mapping:
+      repo-release: keights-release
+      repo-pr: keights-pr
+      version: version-snap
   - task: make-keights
     file: keights-release/ci/tasks/make-keights.yml
     input_mapping:

--- a/ci/tasks/verify-release.yml
+++ b/ci/tasks/verify-release.yml
@@ -1,0 +1,43 @@
+---
+platform: linux
+
+image_resource:
+  type: docker-image
+  source:
+    repository: alpine/git
+    tag: '1.0.4'
+
+inputs:
+- name: repo-release
+- name: repo-pr
+- name: version
+
+run:
+  path: /bin/sh
+  args:
+  - -e
+  - -c
+  - |
+    snap_version=`cut -d - -f 1 version/version`
+    first_char=`echo ${snap_version} | cut -c 1`
+    [ "${first_char=}" = v ] && snap_version=`echo ${snap_version} | cut -c 2-100`
+
+    tag_version=`cut -d - -f 1 repo-release/.git/ref`
+    first_char=`echo ${tag_version} | cut -c 1`
+    [ "${first_char=}" = v ] && tag_version=`echo ${tag_version} | cut -c 2-100`
+
+    if [ "${snap_version}" != "${tag_version=}" ]; then
+        echo "Kubernetes ${tag_version} was not tested, aborting release"
+        exit 1
+    fi
+
+    cd repo-release
+    rel_ref=`git rev-parse HEAD`
+
+    cd ../repo-pr
+    pr_ref=`git rev-parse HEAD`
+
+    if [ "${rel_ref}" != "${pr_ref}" ]; then
+        echo "Tagged version does not match tested PR, aborting release"
+        exit 1
+    fi


### PR DESCRIPTION
This is intended to ensure that the release has been tested by the
pipeline. It checks the PR git ref against the tagged git ref,
and fails if they do not match. It also checks the Kubernetes
version against the one most recently tested.