### PR TITLE
Use Lambda to disable source dest check on EC2 instances

### DIFF
--- a/stack/ansible/keights-stack/tasks/main.yml
+++ b/stack/ansible/keights-stack/tasks/main.yml
@@ -97,6 +97,8 @@
       ApiAccessCidr: '{{ keights_stack.api_access_cidr }}'
       # TODO: give masters and nodes separate ssh_access_cidr
       SshAccessCidr: '{{ keights_stack.ssh_access_cidr }}'
+      KeightsVersion: '{{ keights_version }}'
+      ResourceBucket: '{{ keights_stack.resource_bucket }}'
     tags:
       KubernetesCluster: '{{ keights_stack.cluster_name }}'
       k8s:version: '{{ k8s_version }}'
@@ -125,6 +127,7 @@
       LoadBalancerIdleTimeout: '{{ keights_stack.masters.load_balancer_idle_timeout | default(600) }}'
       MasterSecurityGroups: '{{ ([common_stack.stack_outputs.MasterSecurityGroup] + keights_stack.masters.extra_security_groups | default([])) | join(",") }}'
       LambdaRoleArn: '{{ common_stack.stack_outputs.LambdaRoleArn }}'
+      InstanceAttributeFunctionArn: '{{ common_stack.stack_outputs.InstanceAttributeFunctionArn }}'
       KmsKeyId: '{{ keights_stack.kms_key_alias }}'
       PodCidr: '{{ keights_stack.masters.pod_cidr }}'
       ServiceCidr: '{{ keights_stack.masters.service_cidr }}'
@@ -167,6 +170,7 @@
       KeyPair: '{{ item.keypair }}'
       NodeInstanceProfile: '{{ common_stack.stack_outputs.NodeInstanceProfile }}'
       NodeSecurityGroups: '{{ ([common_stack.stack_outputs.NodeSecurityGroup] + item.extra_security_groups | default([])) | join(",") }}'
+      InstanceAttributeFunctionArn: '{{ common_stack.stack_outputs.InstanceAttributeFunctionArn }}'
       ClusterDns: '{{ cluster_dns }}'
       NodeLabels: '{% set j = joiner(",") %}{% for k, v in item.node_labels.items() | default({}) %}{{ j() }}{{ k }}={{ v }}{% endfor %}'
       LoadBalancerDnsName: '{{ master_stack.stack_outputs.LoadBalancerDnsName }}'

--- a/stack/ansible/keights-system/README.md
+++ b/stack/ansible/keights-system/README.md
@@ -40,7 +40,7 @@ If `plugin` is `calico`, you may set the following keys. These will have no effe
 
 If `plugin` is `kube-router`, you may set the following keys. These will have no effect if `plugin` is `calico`.
 
-`kube_router_image`: (Optional, type *string*, default `cloudnativelabs/kube-router:v0.2.0`) - The kube-router docker image.
+`kube_router_image`: (Optional, type *string*, default `cloudnativelabs/kube-router:v0.2.3`) - The kube-router docker image.
 
 `busybox_image`: (Optional, type *string*, default `busybox:1.28.1`) - The busybox docker image.
 

--- a/stack/ansible/keights-system/templates/manifests/calico.yml.j2
+++ b/stack/ansible/keights-system/templates/manifests/calico.yml.j2
@@ -337,7 +337,7 @@ spec:
               value: "autodetect"
             # Enable IPIP
             - name: CALICO_IPV4POOL_IPIP
-              value: "Always"
+              value: "CrossSubnet"
             # Enable IP-in-IP within Felix.
             - name: FELIX_IPINIPENABLED
               value: "true"

--- a/stack/ansible/keights-system/templates/manifests/kube-router.yml.j2
+++ b/stack/ansible/keights-system/templates/manifests/kube-router.yml.j2
@@ -39,11 +39,12 @@ spec:
       serviceAccountName: kube-router
       containers:
       - name: kube-router
-        image: {{ keights_system.network.kube_router_image | default('cloudnativelabs/kube-router:v0.2.0') }}
+        image: {{ keights_system.network.kube_router_image | default('cloudnativelabs/kube-router:v0.2.3') }}
         args:
         - "--run-router=true"
         - "--run-firewall=true"
         - "--run-service-proxy=false"
+        - "--disable-source-dest-check=false"
         env:
         - name: NODE_NAME
           valueFrom:

--- a/stack/cloudformation/common.yml
+++ b/stack/cloudformation/common.yml
@@ -32,6 +32,12 @@ Parameters:
     Description: CIDR block given ssh access to cluster
     Default: 0.0.0.0/0
     Type: String
+  KeightsVersion:
+    Description: Version of Keights
+    Type: String
+  ResourceBucket:
+    Description: Bucket used to store Lambda archives
+    Type: String
 
 Conditions:
   HasManagedHostedZone: !Equals [!Ref EtcdHostedZoneId, '']
@@ -317,6 +323,7 @@ Resources:
           - Effect: Allow
             Action:
               - 'ec2:Describe*'
+              - 'ec2:ModifyInstanceAttribute'
             Resource:
               - '*'
           - Effect: Allow
@@ -402,6 +409,17 @@ Resources:
               Service: lambda.amazonaws.com
             Action: sts:AssumeRole
 
+  InstanceAttributeFunction:
+    Type: AWS::Lambda::Function
+    Properties:
+      Code:
+        S3Bucket: !Ref ResourceBucket
+        S3Key: !Sub stackbot/instattr/${KeightsVersion}/go1.x/instattr-${KeightsVersion}.zip
+      Handler: instattr
+      Runtime: go1.x
+      Timeout: 30
+      Role: !GetAtt LambdaRole.Arn
+
 Outputs:
   LoadBalancerSecurityGroup:
     Description: Security group of load balancer
@@ -446,3 +464,6 @@ Outputs:
     Description: ID of Route53 DNS hosted zone
     Value: !Ref HostedZone
     Condition: HasManagedHostedZone
+  InstanceAttributeFunctionArn:
+    Description: ARN of Lambda for setting EC2 instance attributes
+    Value: !GetAtt InstanceAttributeFunction.Arn

--- a/stack/cloudformation/master.yml
+++ b/stack/cloudformation/master.yml
@@ -57,6 +57,9 @@ Parameters:
   LambdaRoleArn:
     Description: Role ARN to assign to helper Lamba functions
     Type: String
+  InstanceAttributeFunctionArn:
+    Description: ARN of Lambda for setting EC2 instance attributes
+    Type: String
   KmsKeyId:
     Description: KMS key used to manage secrets
     Type: String
@@ -197,6 +200,26 @@ Resources:
       Principal: events.amazonaws.com
       SourceArn: !GetAtt AutoNamingEventsRule.Arn
 
+  InstanceAttributeEventsRule:
+    Type: AWS::Events::Rule
+    Properties:
+      Targets:
+        - Id: !Sub ${AWS::StackName}-instattr
+          Arn: !Ref InstanceAttributeFunctionArn
+      EventPattern:
+        source: [aws.autoscaling]
+        detail-type: [EC2 Instance Launch Successful]
+        detail:
+          AutoScalingGroupName: [!Ref 'AWS::StackName']
+
+  InstanceAttributeInvokePermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      FunctionName: !Ref InstanceAttributeFunctionArn
+      Action: lambda:InvokeFunction
+      Principal: events.amazonaws.com
+      SourceArn: !GetAtt InstanceAttributeEventsRule.Arn
+
   SubnetToAz:
     Type: Custom::SubnetToAz
     DependsOn: SubnetToAzFunction
@@ -237,7 +260,7 @@ Resources:
 
   AutoScalingGroup:
     Type: AWS::AutoScaling::AutoScalingGroup
-    DependsOn: [KubeCa, AutoNamingInvokePermission]
+    DependsOn: [KubeCa, AutoNamingInvokePermission, InstanceAttributeInvokePermission]
     CreationPolicy:
       ResourceSignal:
         Count: !Ref NumInstances

--- a/stack/cloudformation/node.yml
+++ b/stack/cloudformation/node.yml
@@ -39,6 +39,9 @@ Parameters:
   NodeSecurityGroups:
     Description: Security groups of nodes
     Type: CommaDelimitedList
+  InstanceAttributeFunctionArn:
+    Description: ARN of Lambda for setting EC2 instance attributes
+    Type: String
   ClusterDns:
     Description: >-
       IP addres of cluster DNS server; should be
@@ -72,8 +75,29 @@ Parameters:
       }
 
 Resources:
+  InstanceAttributeEventsRule:
+    Type: AWS::Events::Rule
+    Properties:
+      Targets:
+        - Id: !Sub ${AWS::StackName}-instattr
+          Arn: !Ref InstanceAttributeFunctionArn
+      EventPattern:
+        source: [aws.autoscaling]
+        detail-type: [EC2 Instance Launch Successful]
+        detail:
+          AutoScalingGroupName: [!Ref 'AWS::StackName']
+
+  InstanceAttributeInvokePermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      FunctionName: !Ref InstanceAttributeFunctionArn
+      Action: lambda:InvokeFunction
+      Principal: events.amazonaws.com
+      SourceArn: !GetAtt InstanceAttributeEventsRule.Arn
+
   AutoScalingGroup:
     Type: AWS::AutoScaling::AutoScalingGroup
+    DependsOn: [InstanceAttributeInvokePermission]
     CreationPolicy:
       ResourceSignal:
         Count: !Ref MinInstances


### PR DESCRIPTION
When kube-router handles disabling of source dest check, it can
cause EC2 throttling if the cluster size gets large enough. This
ensures that the attribute is only set once on instance launch,
and disables kube-router from setting the attribute. This also
modifies calico to use `CrossSubnet` mode for IPIP, since the
Lambda can now set the attribute, whereas before it was unset when
using calico.