### PR TITLE
Move Concourse pipeline "ensure" block

### DIFF
--- a/ci/pipelines/keights.yml
+++ b/ci/pipelines/keights.yml
@@ -94,20 +94,20 @@ jobs:
       artifacts-in: build-cluster-artifacts
     output_mapping:
       artifacts-out: run-e2e-artifacts
+    ensure:
+      task: s3-upload-results
+      file: keights-pr/ci/tasks/s3-upload.yml
+      input_mapping:
+        version: version-snap
+        artifacts-in: run-e2e-artifacts
+      params:
+        KEIGHTS_BRANCH: ((git-branch))
+        JOB: build-cluster
   on_failure:
     put: keights-pr
     params:
       path: keights-pr
       status: failure
-  ensure:
-    task: s3-upload-results
-    file: keights-pr/ci/tasks/s3-upload.yml
-    input_mapping:
-      version: version-snap
-      artifacts-in: run-e2e-artifacts
-    params:
-      KEIGHTS_BRANCH: ((git-branch))
-      JOB: build-cluster
 
 - name: upgrade-cluster
   public: true
@@ -148,20 +148,20 @@ jobs:
       artifacts-in: upgraded-cluster-artifacts
     output_mapping:
       artifacts-out: run-e2e-artifacts
+    ensure:
+      task: s3-upload-results
+      file: keights-pr/ci/tasks/s3-upload.yml
+      input_mapping:
+        version: version-snap
+        artifacts-in: run-e2e-artifacts
+      params:
+        KEIGHTS_BRANCH: ((git-branch))
+        JOB: upgrade-cluster
   on_failure:
     put: keights-pr
     params:
       path: keights-pr
       status: failure
-  ensure:
-    task: s3-upload-results
-    file: keights-pr/ci/tasks/s3-upload.yml
-    input_mapping:
-      version: version-snap
-      artifacts-in: run-e2e-artifacts
-    params:
-      KEIGHTS_BRANCH: ((git-branch))
-      JOB: upgrade-cluster
 
 - name: update-pull-request-status
   public: true


### PR DESCRIPTION
The ensure block to upload e2e results to S3 should only run on
the `run-e2e` task, not the whole job.