### PR TITLE
Move Concourse pipeline "ensure" block

### DIFF
--- a/ci/pipelines/keights.yml
+++ b/ci/pipelines/keights.yml
@@ -94,20 +94,20 @@ jobs:
       artifacts-in: build-cluster-artifacts
     output_mapping:
       artifacts-out: run-e2e-artifacts
+    ensure:
+      task: s3-upload-results
+      file: keights-pr/ci/tasks/s3-upload.yml
+      input_mapping:
+        version: version-snap
+        artifacts-in: run-e2e-artifacts
+      params:
+        KEIGHTS_BRANCH: ((git-branch))
+        JOB: build-cluster
   on_failure:
     put: keights-pr
     params:
       path: keights-pr
       status: failure
-  ensure:
-    task: s3-upload-results
-    file: keights-pr/ci/tasks/s3-upload.yml
-    input_mapping:
-      version: version-snap
-      artifacts-in: run-e2e-artifacts
-    params:
-      KEIGHTS_BRANCH: ((git-branch))
-      JOB: build-cluster
 
 - name: upgrade-cluster
   public: true
@@ -148,20 +148,20 @@ jobs:
       artifacts-in: upgraded-cluster-artifacts
     output_mapping:
       artifacts-out: run-e2e-artifacts
+    ensure:
+      task: s3-upload-results
+      file: keights-pr/ci/tasks/s3-upload.yml
+      input_mapping:
+        version: version-snap
+        artifacts-in: run-e2e-artifacts
+      params:
+        KEIGHTS_BRANCH: ((git-branch))
+        JOB: upgrade-cluster
   on_failure:
     put: keights-pr
     params:
       path: keights-pr
       status: failure
-  ensure:
-    task: s3-upload-results
-    file: keights-pr/ci/tasks/s3-upload.yml
-    input_mapping:
-      version: version-snap
-      artifacts-in: run-e2e-artifacts
-    params:
-      KEIGHTS_BRANCH: ((git-branch))
-      JOB: upgrade-cluster
 
 - name: update-pull-request-status
   public: true

--- a/stack/ami/debian/build.json
+++ b/stack/ami/debian/build.json
@@ -6,7 +6,7 @@
     "docker-vol": "xvdf",
     "docker-version": "17.03.1~ce-0~debian-stretch",
     "k8s-version": "1.11.4",
-    "cni-version": "0.6.0",
+    "cni-version": "0.7.5",
     "core-dns-version": "1.1.3",
     "etcd-version": "3.2.18",
     "pause-version": "3.1",


### PR DESCRIPTION
The ensure block to upload e2e results to S3 should only run on
the `run-e2e` task, not the whole job.