### PR TITLE
Fix AMI build

### DIFF
--- a/stack/ami/debian/playbook.yml
+++ b/stack/ami/debian/playbook.yml
@@ -58,7 +58,6 @@
       - apt-transport-https
       - bind9-host
       - btrfs-progs
-      - btrfs-tools
       - ca-certificates
       - curl
       - dbus
@@ -66,6 +65,7 @@
       - ebtables
       - ethtool
       - file
+      - gnupg2
       - groff-base
       - less
       - linux-image-amd64


### PR DESCRIPTION
Modify Debian packages installed in AMI
    
AMI build now fails with:
    
* "Couldn't find these debs: btrfs-tools".
* "E: gnupg, gnupg2 and gnupg1 do not seem to be installed, but
   one of them is required for this operation".
