### PR TITLE
Pin Debian release to stretch instead of stable

### DIFF
--- a/stack/ami/debian/build.json
+++ b/stack/ami/debian/build.json
@@ -115,7 +115,8 @@
 	"-e", "docker_version={{ user `docker-version` }}",
 	"-e", "k8s_version={{ user `k8s-version` }}",
 	"-e", "keights_version={{ user `keights-version` }}",
-	"-e", "cni_version={{ user `cni-version` }}"
+	"-e", "cni_version={{ user `cni-version` }}",
+	"-e", "debian_release={{ user `debian-release` }}"
       ]
     }
   ]

--- a/stack/ami/debian/playbook.yml
+++ b/stack/ami/debian/playbook.yml
@@ -111,7 +111,7 @@
           --merged-usr \
           --exclude={{ bootstrap_exclude | join(",") }} \
           --include={{ bootstrap_include | join(",") }} \
-          stable /mnt {{ base_repo }}
+          {{ debian_release }} /mnt {{ base_repo }}
       args:
         # Pick a file, any file...
         creates: /mnt/usr/bin/vi


### PR DESCRIPTION
Debian stable is now buster, which causes breakage due to iptables
update, see https://github.com/kubernetes/kubernetes/issues/71305.