### PR TITLE
Update calico-typha cluster-proportional-autoscaler

### DIFF
--- a/stack/ansible/keights-system/README.md
+++ b/stack/ansible/keights-system/README.md
@@ -40,7 +40,7 @@ If `plugin` is `calico`, you may set the following keys. These will have no effe
 
 `typha_image`: (Optional, type *string*, default `calico/typha:v3.9.1`) - The [Typha](https://github.com/projectcalico/typha) docker image.
 
-`typha_autoscaler_image` (Optional, type *string*, default `k8s.gcr.io/cluster-proportional-autoscaler-amd64:1.1.2`) - The Typha autoscaler docker image.
+`typha_autoscaler_image` (Optional, type *string*, default `k8s.gcr.io/cluster-proportional-autoscaler-amd64:1.7.1`) - The Typha autoscaler docker image.
 
 If `plugin` is `kube-router`, you may set the following keys. These will have no effect if `plugin` is `calico`.
 

--- a/stack/ansible/keights-system/templates/manifests/calico.yml.j2
+++ b/stack/ansible/keights-system/templates/manifests/calico.yml.j2
@@ -906,7 +906,7 @@ metadata:
 rules:
   - apiGroups: [""]
     resources: ["nodes"]
-    verbs: ["list"]
+    verbs: ["list", "watch"]
 
 ---
 
@@ -956,7 +956,7 @@ spec:
       nodeSelector:
         beta.kubernetes.io/os: linux
       containers:
-        - image: {{ keights_system.network.typha_autoscaler_image | default('k8s.gcr.io/cluster-proportional-autoscaler-amd64:1.1.2') }}
+        - image: {{ keights_system.network.typha_autoscaler_image | default('k8s.gcr.io/cluster-proportional-autoscaler-amd64:1.7.1') }}
           name: autoscaler
           command:
             - /cluster-proportional-autoscaler
@@ -983,7 +983,7 @@ rules:
   - apiGroups: [""]
     resources: ["configmaps"]
     verbs: ["get"]
-  - apiGroups: ["extensions"]
+  - apiGroups: ["apps", "extensions"]
     resources: ["deployments/scale"]
     verbs: ["get", "update"]
 


### PR DESCRIPTION
This updates cluster-proportional-autoscaler to a newer version to work with
Kubernetes 1.16, and modifies RBAC for 1.16.