### PR TITLE
Route reflectors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,9 @@ keights-stack:
 	tar czf _output/keights-stack-$(VERSION).tar.gz -C _output keights-stack
 
 keights-system:
-	tar czf _output/keights-system-$(VERSION).tar.gz -C stack/ansible keights-system
+	cp -R stack/ansible/keights-system _output
+	echo $(VERSION) > _output/keights-system/version
+	tar czf _output/keights-system-$(VERSION).tar.gz -C _output keights-system
 
 stackbot:
 	for bot in auto_namer instattr kube_ca subnet_to_az; do \

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ All builds and tests are run on [Concourse CI](https://ci.cloudboss.xyz/teams/ke
 | ----- | ------- | ------ |
 | build-pull-request | 1.16 | [![Build Status](https://ci.cloudboss.xyz/api/v1/teams/keights/pipelines/keights-v1.16/jobs/build-pull-request/badge)](https://ci.cloudboss.xyz/teams/keights/pipelines/keights-v1.16/jobs/build-pull-request/builds/latest) |
 | build-cluster | 1.16 | [![Build Status](https://ci.cloudboss.xyz/api/v1/teams/keights/pipelines/keights-v1.16/jobs/build-cluster/badge)](https://ci.cloudboss.xyz/teams/keights/pipelines/keights-v1.16/jobs/build-cluster/builds/latest) |
-| upgrade-cluster | 1.15 -> 1.16 | [![Build Status](https://ci.cloudboss.xyz/api/v1/teams/keights/pipelines/keights-v1.16/jobs/upgrade-cluster/badge)](https://ci.cloudboss.xyz/teams/keights/pipelines/keights-v1.15/jobs/upgrade-cluster/builds/latest) |
+| upgrade-cluster | 1.15 -> 1.16 | [![Build Status](https://ci.cloudboss.xyz/api/v1/teams/keights/pipelines/keights-v1.16/jobs/upgrade-cluster/badge)](https://ci.cloudboss.xyz/teams/keights/pipelines/keights-v1.16/jobs/upgrade-cluster/builds/latest) |
 | build-release | 1.16 | [![Build Status](https://ci.cloudboss.xyz/api/v1/teams/keights/pipelines/keights-v1.16/jobs/build-release/badge)](https://ci.cloudboss.xyz/teams/keights/pipelines/keights-v1.16/jobs/build-release/builds/latest) |
 ||||
 | build-pull-request | 1.15 | [![Build Status](https://ci.cloudboss.xyz/api/v1/teams/keights/pipelines/keights-v1.15/jobs/build-pull-request/badge)](https://ci.cloudboss.xyz/teams/keights/pipelines/keights-v1.15/jobs/build-pull-request/builds/latest) |

--- a/ci/assets/v1.16/cluster/playbook.yml
+++ b/ci/assets/v1.16/cluster/playbook.yml
@@ -30,3 +30,5 @@
       cluster_apiserver: '{{ master_stack.stack_outputs.LoadBalancerDnsName }}'
       network:
         plugin: kube-router
+        # Let the masters act as route reflectors for CI clusters
+        rr_node_label: node-role.kubernetes.io/master

--- a/stack/ansible/keights-system/README.md
+++ b/stack/ansible/keights-system/README.md
@@ -24,6 +24,10 @@ All role variables go under a top level dictionary `keights_system`.
 
 The `network` dictionary may contain the following keys:
 
+`rr_node_label`: (Optional, type *string*, default `''`) - If defined, nodes with this label will be configured as route reflectors (see [here](https://docs.projectcalico.org/v3.9/networking/routereflector) and [here](https://github.com/cloudnativelabs/kube-router/blob/master/docs/bgp.md#route-reflector-setup--without-full-mesh)). To set the label on nodes, define it within [`node_labels`](https://github.com/cloudboss/keights/tree/master/stack/ansible/keights-stack#node_groups) when creating a node group. The value of the label is not important, only the presence of the label. Caution: if `rr_node_label` is defined and no nodes have a matching label, there will be no networking!
+
+`rr_cluster_id`: (Optional, type *string*, default `10.0.0.1` for calico, `42` for kube-router) - Route reflector cluster ID when `rr_node_label` is defined. Calico expects the cluster ID to be an IPv4 address, while kube-router expects an integer.
+
 `plugin`: (Required, type *string*) - May be one of `calico`, `kube-router`.
 
 If `plugin` is `calico`, you may set the following keys. These will have no effect if `plugin` is `kube-router`.
@@ -33,6 +37,8 @@ If `plugin` is `calico`, you may set the following keys. These will have no effe
 `cni_image`: (Optional, type *string*, default `calico/cni:v3.9.1`) - The CNI docker image.
 
 `calico_node_image`: (Optional, type *string*, default `calico/node:v3.9.1`) - The Calico node docker image.
+
+`calico_ctl_image`: (Optional, type *string*, default `calico/ctl:v3.9.1`) - The Calico ctl docker image.
 
 `pod2daemon_flexvol_image`: (Optional, type *string*, default `calico/pod2daemon-flexvol:v3.9.1`) - The Calico flex volume driver docker image.
 
@@ -47,6 +53,8 @@ If `plugin` is `kube-router`, you may set the following keys. These will have no
 `kube_router_image`: (Optional, type *string*, default `cloudnativelabs/kube-router:v0.3.2`) - The kube-router docker image.
 
 `busybox_image`: (Optional, type *string*, default `busybox:1.30.1`) - The busybox docker image.
+
+`kubectl_image`: (Optional, type *string*, default `k8s.gcr.io/hyperkube:${k8s_version}`) - The kubectl docker image.
 
 # Example Playbook
 

--- a/stack/ansible/keights-system/tasks/main.yml
+++ b/stack/ansible/keights-system/tasks/main.yml
@@ -5,16 +5,33 @@
   with_file:
     - '{{ role_path }}/version'
 
-- name: set default values
+- name: set kubernetes version
   set_fact:
     k8s_version: '{{ keights_system.k8s_version | default(keights_version.split("-")[0]) }}'
-    rr_cluster_id: '{{ keights_system.network.rr_cluster_id | default(42) }}'
+
+- name: set route reflector cluster id
+  set_fact:
+    rr_cluster_id: '{{ keights_system.network.rr_cluster_id | default("10.0.0.1") }}'
+  when: "keights_system.network.plugin == 'calico'"
+
+- name: assert that route reflector cluster id is an ipv4 address
+  assert:
+    that:
+      - "'{{ rr_cluster_id }}' | regex_search('([0-9]{1,3}\\.){3}[0-9]{1,3}')"
+    msg: '`keights_system.network.rr_cluster_id` must be an ipv4 address'
+  when: "keights_system.network.plugin == 'calico'"
+
+- name: set route reflector cluster id
+  set_fact:
+    rr_cluster_id: '{{ keights_system.network.rr_cluster_id | default("42") }}'
+  when: "keights_system.network.plugin == 'kube-router'"
 
 - name: assert that route reflector cluster id is an integer
   assert:
     that:
-      - '{{ rr_cluster_id | int }}'
+      - 'rr_cluster_id | int'
     msg: '`keights_system.network.rr_cluster_id` must be an integer'
+  when: "keights_system.network.plugin == 'kube-router'"
 
 - name: define ssm paths
   set_fact:

--- a/stack/ansible/keights-system/tasks/main.yml
+++ b/stack/ansible/keights-system/tasks/main.yml
@@ -1,4 +1,21 @@
 ---
+- name: set keights version
+  set_fact:
+    keights_version: '{{ item }}'
+  with_file:
+    - '{{ role_path }}/version'
+
+- name: set default values
+  set_fact:
+    k8s_version: '{{ keights_system.k8s_version | default(keights_version.split("-")[0]) }}'
+    rr_cluster_id: '{{ keights_system.network.rr_cluster_id | default(42) }}'
+
+- name: assert that route reflector cluster id is an integer
+  assert:
+    that:
+      - '{{ rr_cluster_id | int }}'
+    msg: '`keights_system.network.rr_cluster_id` must be an integer'
+
 - name: define ssm paths
   set_fact:
     ca_cert_ssm_path: '/{{ keights_system.cluster_name }}/cluster/ca.crt'

--- a/stack/ansible/keights-system/templates/manifests/calico.yml.j2
+++ b/stack/ansible/keights-system/templates/manifests/calico.yml.j2
@@ -1,3 +1,4 @@
+#jinja2: trim_blocks:False
 # Calico Version v3.9.1
 # https://docs.projectcalico.org/v3.9/introduction
 ---
@@ -406,6 +407,49 @@ spec:
       terminationGracePeriodSeconds: 0
       priorityClassName: system-node-critical
       initContainers:
+        {% if keights_system.network.rr_node_label | default('') %}
+        # This container adds a route reflector cluster ID to
+        # a node if one of its labels matches `RR_NODE_LABEL`.
+        - name: update-node
+          image: {{ keights_system.network.calico_ctl_image | default('calico/ctl:v3.9.1') }}
+          env:
+            - name: DATASTORE_TYPE
+              value: kubernetes
+            - name: RR_CLUSTER_ID
+              value: "{{ rr_cluster_id }}"
+            - name: RR_NODE_LABEL
+              value: "{{ keights_system.network.rr_node_label }}"
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          command: [/bin/sh]
+          args:
+            - -xec
+            - |
+              # Iterate over all node labels and output the matching label if found.
+              # `index .ObjectMeta.Labels` cannot be used, because labels with empty
+              # values and nonexistent labels both return the empty string.
+              label=`calicoctl get no ${NODE_NAME} \
+                  -o go-template="{% raw %}{{range .}}{{range \\$k, \\$_ := .ObjectMeta.Labels}}{{if eq \\$k \"${RR_NODE_LABEL}\"}}{{\\$k}}{{end}}{{end}}{{end}}{% endraw %}"`
+
+              [ -n "${label}" ] || exit 0
+
+              spec_bgp=`calicoctl get no ${NODE_NAME} \
+                  -o go-template='{% raw %}{{range .}}{{.Spec.BGP}}{{end}}{% endraw %}'`
+
+              if [ "${spec_bgp}" != "<nil>" ]; then
+                  rr_cluster_id=`calicoctl get no ${NODE_NAME} \
+                      -o go-template='{% raw %}{{range .}}{{.Spec.BGP.RouteReflectorClusterID}}{{end}}{% endraw %}'`
+                  # Route reflector cluster ID is already set.
+                  [ -z "${rr_cluster_id}" ] || exit 0
+              fi
+
+              calicoctl get node ${NODE_NAME} -o yaml --export | sed "s|spec: {}|spec:\n  bgp:|g" > node.yaml
+              echo "    routeReflectorClusterID: ${RR_CLUSTER_ID}" >> node.yaml
+              calicoctl apply -f node.yaml
+        {% endif %}
+
         # This container performs upgrade from host-local IPAM to calico-ipam.
         # It can be deleted if this is a fresh installation, or if you have already
         # upgraded to use calico-ipam.
@@ -823,6 +867,39 @@ spec:
     kind: NetworkSet
     plural: networksets
     singular: networkset
+
+{% if keights_system.network.rr_node_label | default('') %}
+---
+
+kind: BGPPeer
+apiVersion: crd.projectcalico.org/v1
+metadata:
+  name: peer-to-rrs
+spec:
+  nodeSelector: '!has({{ keights_system.network.rr_node_label }})'
+  peerSelector: 'has({{ keights_system.network.rr_node_label }})'
+
+---
+
+kind: BGPPeer
+apiVersion: crd.projectcalico.org/v1
+metadata:
+  name: rr-mesh
+spec:
+  nodeSelector: 'has({{ keights_system.network.rr_node_label }})'
+  peerSelector: 'has({{ keights_system.network.rr_node_label }})'
+
+---
+
+apiVersion: crd.projectcalico.org/v1
+kind: BGPConfiguration
+metadata:
+  name: default
+spec:
+  logSeverityScreen: Info
+  nodeToNodeMeshEnabled: false
+
+{% endif %}
 
 ---
 

--- a/stack/ansible/keights-system/templates/manifests/kube-router.yml.j2
+++ b/stack/ansible/keights-system/templates/manifests/kube-router.yml.j2
@@ -1,3 +1,4 @@
+#jinja2: trim_blocks:False
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -75,6 +76,34 @@ spec:
         - name: cni-conf-dir
           mountPath: /etc/cni/net.d
       initContainers:
+      {% if keights_system.network.rr_node_label | default('') %}
+      # Label a node so you can annotate a node...
+      - name: annotate-node
+        image: {{ keights_system.network.kubectl_image | default('k8s.gcr.io/hyperkube:{}'.format(k8s_version)) }}
+        imagePullPolicy: IfNotPresent
+        env:
+        - name: RR_NODE_LABEL
+          value: "{{ keights_system.network.rr_node_label }}"
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        command:
+        - /bin/sh
+        - -xec
+        - |
+          found_label=`kubectl get no ${NODE_NAME} \
+              -o go-template \
+              --template="{% raw %}{{range \\$k, \\$_ := .metadata.labels}}{{if eq \\$k \"${RR_NODE_LABEL}\"}}{{\\$k}}{{end}}{{end}}{% endraw %}"`
+
+          if [ -n "${found_label}" ]; then
+              kubectl patch no ${NODE_NAME} \
+                  --patch '{"metadata":{"annotations":{"kube-router.io/rr.server":"{{ rr_cluster_id }}"}}}'
+          else
+              kubectl patch no ${NODE_NAME} \
+                  --patch '{"metadata":{"annotations":{"kube-router.io/rr.client":"{{ rr_cluster_id }}"}}}'
+          fi
+      {% endif %}
       - name: install-cni
         image: {{ keights_system.network.busybox_image | default('busybox:1.30.1') }}
         imagePullPolicy: IfNotPresent
@@ -140,6 +169,12 @@ rules:
       - list
       - get
       - watch
+  - apiGroups:
+    - ""
+    resources:
+      - nodes
+    verbs:
+      - patch
   - apiGroups:
     - "networking.k8s.io"
     resources:


### PR DESCRIPTION
This adds the ability to configure kube-router or calico to use route reflectors based on node labels.