### PR TITLE
Update Concourse pipeline to use newer GitHub PR resource

### DIFF
--- a/ci/pipelines/keights.yml
+++ b/ci/pipelines/keights.yml
@@ -2,7 +2,8 @@ resource_types:
 - name: pull-request
   type: docker-image
   source:
-    repository: jtarchie/pr
+    repository: teliaoss/github-pr-resource
+    tag: v0.21.0
 
 resources:
 - name: version-snap
@@ -19,11 +20,9 @@ resources:
   webhook_token: ((github-keights-webhook-token))
   source:
     access_token: ((github-access-token))
-    private_key: ((github-deploy-key-keights))
-    base: ((git-branch))
-    repo: cloudboss/keights
-    require_review_approval: true
-    only_mergeable: true
+    base_branch: ((git-branch))
+    repository: cloudboss/keights
+    required_review_approvals: 1
 - name: keights-release
   type: git
   check_every: 12h

--- a/stack/ami/debian/build.json
+++ b/stack/ami/debian/build.json
@@ -9,7 +9,6 @@
     "var-log-vol": "xvdf",
     "docker-version": "5:18.09.9~3-0~debian-buster",
     "k8s-version": "",
-    "cni-version": "0.7.5",
     "share-accounts": "all",
     "base-ami-pattern": "debian-stretch-hvm-x86_64-gp2-*",
     "base-ami-owner": "379101102735",
@@ -90,8 +89,7 @@
       "os:version": "debian-{{ user `debian-release` }}",
       "docker:version": "{{ user `docker-version` }}",
       "k8s:version": "{{ user `k8s-version` }}",
-      "keights:version": "{{ user `keights-version` }}",
-      "cni:version": "{{ user `cni-version` }}"
+      "keights:version": "{{ user `keights-version` }}"
     },
 
     "run_tags": {
@@ -121,7 +119,6 @@
 	"-e", "docker_version={{ user `docker-version` }}",
 	"-e", "k8s_version={{ user `k8s-version` }}",
 	"-e", "keights_version={{ user `keights-version` }}",
-	"-e", "cni_version={{ user `cni-version` }}",
 	"-e", "debian_release={{ user `debian-release` }}"
       ]
     }

--- a/stack/ami/debian/playbook.yml
+++ b/stack/ami/debian/playbook.yml
@@ -180,7 +180,6 @@
           openssh-server \
           docker-ce={{ docker_version }} \
           docker-ce-cli={{ docker_version }} \
-          kubernetes-cni={{ cni_version }}-00 \
           kubectl={{ k8s_version_no_v }}-00 \
           kubeadm={{ k8s_version_no_v }}-00 \
           kubelet={{ k8s_version_no_v }}-00 && \


### PR DESCRIPTION
This replaces the deprecated `jtarchie/pr` with `teliaoss/github-pr-resource`.