### PR TITLE
Fix pipeline task comparing git commits

### DIFF
--- a/ci/tasks/verify-release.yml
+++ b/ci/tasks/verify-release.yml
@@ -34,8 +34,7 @@ run:
     cd repo-release
     rel_ref=`git log --no-merges --format=%H -n 1`
 
-    cd ../repo-pr
-    pr_ref=`git rev-parse HEAD`
+    pr_ref=`cat ../repo-pr/.git/resource/head_sha`
 
     if [ "${rel_ref}" != "${pr_ref}" ]; then
         echo "Tagged version does not match tested PR, aborting release"


### PR DESCRIPTION
With the newer `teliaoss/github-pr-resource` Concourse resource being used for
GitHub PRs, comparison of git commits works differently. This changes the task
to look in a file written by the resource to get the head commit of the PR.