### PR TITLE
Update CI images to use a registry mirror

### DIFF
--- a/ci/pipelines/keights.yml
+++ b/ci/pipelines/keights.yml
@@ -2,7 +2,7 @@ resource_types:
 - name: pull-request
   type: docker-image
   source:
-    repository: teliaoss/github-pr-resource
+    repository: cloudboss.jfrog.io/containers/teliaoss/github-pr-resource
     tag: v0.21.0
 
 resources:

--- a/ci/tasks/build-ami.yml
+++ b/ci/tasks/build-ami.yml
@@ -4,7 +4,7 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: python
+    repository: cloudboss.jfrog.io/containers/python
     tag: '3.6'
 
 inputs:

--- a/ci/tasks/build-cluster.yml
+++ b/ci/tasks/build-cluster.yml
@@ -4,7 +4,7 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: python
+    repository: cloudboss.jfrog.io/containers/python
     tag: '3.6'
 
 inputs:

--- a/ci/tasks/delete-cluster.yml
+++ b/ci/tasks/delete-cluster.yml
@@ -4,7 +4,7 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: python
+    repository: cloudboss.jfrog.io/containers/python
     tag: '3.6'
 
 inputs:

--- a/ci/tasks/make-keights.yml
+++ b/ci/tasks/make-keights.yml
@@ -4,7 +4,7 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: golang
+    repository: cloudboss.jfrog.io/containers/golang
     tag: '1.13.3'
 
 inputs:

--- a/ci/tasks/run-e2e.yml
+++ b/ci/tasks/run-e2e.yml
@@ -4,7 +4,7 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: alpine
+    repository: cloudboss.jfrog.io/containers/alpine
     tag: '3.8'
 
 inputs:

--- a/ci/tasks/s3-upload.yml
+++ b/ci/tasks/s3-upload.yml
@@ -4,7 +4,7 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: python
+    repository: cloudboss.jfrog.io/containers/python
     tag: '3.7.2-alpine'
 
 inputs:

--- a/ci/tasks/verify-release.yml
+++ b/ci/tasks/verify-release.yml
@@ -4,7 +4,7 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: alpine/git
+    repository: cloudboss.jfrog.io/containers/alpine/git
     tag: '1.0.4'
 
 inputs:


### PR DESCRIPTION
To avoid docker hub rate limiting, images will be pulled from
cloudboss.jfrog.io/containers.