### PR TITLE
Pass apiserver into instances from CloudFormation

### DIFF
--- a/stack/ansible/keights-system/templates/manifests/kube-router.yml.j2
+++ b/stack/ansible/keights-system/templates/manifests/kube-router.yml.j2
@@ -74,7 +74,7 @@ spec:
       serviceAccountName: kube-router
       containers:
       - name: kube-router
-        image: {{ keights_system.network.kube_router_image | default('cloudnativelabs/kube-router:v1.3.0') }}
+        image: {{ keights_system.network.kube_router_image | default('cloudnativelabs/kube-router:v1.3.1') }}
         imagePullPolicy: IfNotPresent
         args:
         - --run-router=true

--- a/stack/ansible/keights-system/templates/manifests/kube-router.yml.j2
+++ b/stack/ansible/keights-system/templates/manifests/kube-router.yml.j2
@@ -8,6 +8,25 @@ metadata:
     tier: node
     k8s-app: kube-router
 data:
+  kubeconfig.template: |
+    apiVersion: v1
+    kind: Config
+    clusters:
+    - cluster:
+        certificate-authority: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+        server: __APISERVER__
+      name: default
+    contexts:
+    - context:
+        cluster: default
+        namespace: default
+        user: default
+      name: default
+    current-context: default
+    users:
+    - name: default
+      user:
+        tokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
   cni-conf.json: |
     {
       "cniVersion": "0.3.1",
@@ -63,6 +82,7 @@ spec:
         - --run-service-proxy={{ keights_system.network.replace_kube_proxy | default(false) | to_json }}
         - --disable-source-dest-check=false
         - --bgp-graceful-restart=true
+        - --kubeconfig=/kube-router/kubeconfig
         env:
         - name: NODE_NAME
           valueFrom:
@@ -94,43 +114,24 @@ spec:
         - name: kube-router
           mountPath: /kube-router
       initContainers:
-      {% if keights_system.network.rr_node_label | default('') %}
       - name: write-kubeconfig
         image: {{ keights_system.network.busybox_image | default('busybox:1.30.1') }}
         command:
         - /bin/sh
         - -xec
         - |
-          # Borrow the kubelet's kubeconfig to get the apiserver's public DNS,
-          # to be able to connect before the internal network is up.
-          # See https://github.com/cloudnativelabs/kube-router/issues/859.
-          apiserver=`awk '/ server: https:/{print $2}' /etc/kubernetes/kubelet.conf`
-          cat > /kube-router/kubeconfig <<EOF
-          apiVersion: v1
-          kind: Config
-          clusters:
-          - cluster:
-              certificate-authority: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-              server: ${apiserver}
-            name: default
-          contexts:
-          - context:
-              cluster: default
-              namespace: default
-              user: default
-            name: default
-          current-context: default
-          users:
-          - name: default
-            user:
-              tokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
-          EOF
+          apiserver=`cat /etc/kubernetes/apiserver`
+          template=/etc/kube-router/kubeconfig.template
+          sed "s|__APISERVER__|https://${apiserver}|g" ${template} > /kube-router/kubeconfig
         volumeMounts:
-        - name: kubelet-conf
-          mountPath: /etc/kubernetes/kubelet.conf
+        - name: apiserver
+          mountPath: /etc/kubernetes/apiserver
           readOnly: true
         - name: kube-router
           mountPath: /kube-router
+        - name: kube-router-cfg
+          mountPath: /etc/kube-router
+      {% if keights_system.network.rr_node_label | default('') %}
       # Label a node so you can annotate a node...
       - name: annotate-node
         image: {{ keights_system.network.kubectl_image | default('bitnami/kubectl:1.18.8') }}
@@ -205,9 +206,9 @@ spec:
       - name: kube-router-cfg
         configMap:
           name: kube-router-cfg
-      - name: kubelet-conf
+      - name: apiserver
         hostPath:
-          path: /etc/kubernetes/kubelet.conf
+          path: /etc/kubernetes/apiserver
       - name: kube-router
         emptyDir:
           medium: Memory

--- a/stack/cloudformation/master-external.yml
+++ b/stack/cloudformation/master-external.yml
@@ -228,6 +228,11 @@ Resources:
             - |
               #cloud-config
               write_files:
+              - path: /etc/kubernetes/apiserver
+                owner: root:root
+                permissions: '0644'
+                content: ${LoadBalancer.DNSName}
+
               - path: /etc/keights/kubeadm-init-config.yaml.template
                 owner: root:root
                 permissions: '0644'

--- a/stack/cloudformation/master-stacked.yml
+++ b/stack/cloudformation/master-stacked.yml
@@ -369,6 +369,11 @@ Resources:
             - |
               #cloud-config
               write_files:
+              - path: /etc/kubernetes/apiserver
+                owner: root:root
+                permissions: '0644'
+                content: ${LoadBalancer.DNSName}
+
               - path: /etc/keights/kubeadm-init-config.yaml.template
                 owner: root:root
                 permissions: '0644'

--- a/stack/cloudformation/node.yml
+++ b/stack/cloudformation/node.yml
@@ -219,6 +219,11 @@ Resources:
             - |
               #cloud-config
               write_files:
+              - path: /etc/kubernetes/apiserver
+                owner: root:root
+                permissions: '0644'
+                content: ${LoadBalancerDnsName}
+
               - path: /etc/keights/kubeadm-join-config.yaml.template
                 owner: root:root
                 permissions: '0644'


### PR DESCRIPTION
Kube-router needs to communicate with the apiserver on the load balancer when
`replace_kube_proxy: true`. This writes the DNS name of the load balancer to a
file on all instances so it can be mounted as a volume for kube-router. An init
container uses the value from the file to expand a kubeconfig template
placeholder.

This also modifies the kube-router manifest to store the kubeconfig template in a
ConfigMap instead of writing it with a shell heredoc.